### PR TITLE
chore: set timeout-minutes to GitHub Actions workflow

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   assign:
+    timeout-minutes: 15
     name: Set assignees and reviewers
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   publish-gpr:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
GitHub Actions のワークフローの `timeout-minutes` を設定しました。
https://www.notion.so/400f/CI-job-timeout-1b6a4fdf5b8d805c8c66d8c3b48103cf
